### PR TITLE
feat(openapi3): add spec diff (SpecMetadataDiff) and oas3diff CLI

### DIFF
--- a/cmd/oas3diff/main.go
+++ b/cmd/oas3diff/main.go
@@ -1,0 +1,41 @@
+// oas3diff compares two OpenAPI 3 specs (JSON or YAML) and reports the
+// endpoints, operation IDs, and schema names unique to each.
+//
+// Usage:
+//
+//	oas3diff <spec1> <spec2>
+//
+// Endpoints are compared generically (path variables normalized), so a diff in
+// operationId names does not hide the fact that the same endpoint exists in both.
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+
+	"github.com/grokify/spectrum/openapi3"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		slog.Error("usage: oas3diff <spec1> <spec2>")
+		os.Exit(1)
+	}
+	file1, file2 := os.Args[1], os.Args[2]
+
+	diff, err := openapi3.ReadSpecsDiff(file1, file2, false)
+	if err != nil {
+		slog.Error(strconv.Quote(err.Error()))
+		os.Exit(2)
+	}
+
+	fmt.Printf("spec 1: %s\nspec 2: %s\n\n", file1, file2)
+	fmt.Print(diff.String())
+
+	if diff.IsEmpty() {
+		fmt.Println("\nno differences")
+	}
+	os.Exit(0)
+}

--- a/openapi3/difference.go
+++ b/openapi3/difference.go
@@ -1,0 +1,105 @@
+package openapi3
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/grokify/mogo/type/stringsutil"
+)
+
+// SpecMetadataDiff holds a set comparison of two specs' metadata across the
+// three dimensions tracked by SpecMetadata: endpoints (generic `path method`),
+// operation IDs, and schema names. It is the complement of IntersectionData and
+// is useful for spotting version drift, verifying a migration lost no coverage,
+// or measuring what a newer spec adds.
+type SpecMetadataDiff struct {
+	OnlyInSpec1 SpecMetadata // present in spec 1 but not spec 2
+	OnlyInSpec2 SpecMetadata // present in spec 2 but not spec 1
+	Both        SpecMetadata // present in both
+}
+
+func NewSpecMetadataDiff() SpecMetadataDiff {
+	return SpecMetadataDiff{
+		OnlyInSpec1: NewSpecMetadata(),
+		OnlyInSpec2: NewSpecMetadata(),
+		Both:        NewSpecMetadata()}
+}
+
+// Sort sorts every dimension of each side of the diff.
+func (d *SpecMetadataDiff) Sort() {
+	d.OnlyInSpec1.Sort()
+	d.OnlyInSpec2.Sort()
+	d.Both.Sort()
+}
+
+// IsEmpty reports whether the two specs were identical across all dimensions,
+// i.e. neither side had anything the other lacked.
+func (d *SpecMetadataDiff) IsEmpty() bool {
+	return d.OnlyInSpec1.IsEmpty() && d.OnlyInSpec2.IsEmpty()
+}
+
+// String renders a human-readable report of the differences, listing the
+// items unique to each spec per dimension. Items common to both are summarized
+// by count only.
+func (d SpecMetadataDiff) String() string {
+	d.Sort()
+	var sb strings.Builder
+	writeDim := func(name string, only1, only2, both []string) {
+		fmt.Fprintf(&sb, "%s: %d in both, %d only in spec 1, %d only in spec 2\n",
+			name, len(both), len(only1), len(only2))
+		for _, v := range only1 {
+			fmt.Fprintf(&sb, "  - only in spec 1: %s\n", v)
+		}
+		for _, v := range only2 {
+			fmt.Fprintf(&sb, "  + only in spec 2: %s\n", v)
+		}
+	}
+	writeDim("Endpoints", d.OnlyInSpec1.Endpoints, d.OnlyInSpec2.Endpoints, d.Both.Endpoints)
+	writeDim("OperationIDs", d.OnlyInSpec1.OperationIDs, d.OnlyInSpec2.OperationIDs, d.Both.OperationIDs)
+	writeDim("SchemaNames", d.OnlyInSpec1.SchemaNames, d.OnlyInSpec2.SchemaNames, d.Both.SchemaNames)
+	return sb.String()
+}
+
+// Difference returns the metadata present in md but not in md2, evaluated
+// independently for each dimension.
+func (md *SpecMetadata) Difference(md2 SpecMetadata) SpecMetadata {
+	return SpecMetadata{
+		Endpoints:    stringsutil.SliceSubtract(md.Endpoints, md2.Endpoints),
+		OperationIDs: stringsutil.SliceSubtract(md.OperationIDs, md2.OperationIDs),
+		SchemaNames:  stringsutil.SliceSubtract(md.SchemaNames, md2.SchemaNames)}
+}
+
+// Diff returns a three-way comparison (only in md, only in md2, both) of the
+// receiver against md2.
+func (md *SpecMetadata) Diff(md2 SpecMetadata) SpecMetadataDiff {
+	d := SpecMetadataDiff{
+		OnlyInSpec1: md.Difference(md2),
+		OnlyInSpec2: md2.Difference(*md),
+		Both:        md.Intersection(md2)}
+	d.Sort()
+	return d
+}
+
+// SpecsDiff compares two specs across endpoints, operation IDs, and schema
+// names, returning the items unique to each and those shared.
+func SpecsDiff(spec1, spec2 *Spec) SpecMetadataDiff {
+	sm1 := SpecMore{Spec: spec1}
+	sm2 := SpecMore{Spec: spec2}
+	md1 := sm1.Metadata()
+	md2 := sm2.Metadata()
+	return md1.Diff(md2)
+}
+
+// ReadSpecsDiff reads two OpenAPI 3 specs from file (JSON or YAML) and diffs
+// them. It is a convenience wrapper over ReadFile and SpecsDiff.
+func ReadSpecsDiff(file1, file2 string, validate bool) (SpecMetadataDiff, error) {
+	spec1, err := ReadFile(file1, validate)
+	if err != nil {
+		return NewSpecMetadataDiff(), fmt.Errorf("reading spec 1 (%s): %w", file1, err)
+	}
+	spec2, err := ReadFile(file2, validate)
+	if err != nil {
+		return NewSpecMetadataDiff(), fmt.Errorf("reading spec 2 (%s): %w", file2, err)
+	}
+	return SpecsDiff(spec1, spec2), nil
+}

--- a/openapi3/difference_test.go
+++ b/openapi3/difference_test.go
@@ -1,0 +1,83 @@
+package openapi3
+
+import (
+	"reflect"
+	"testing"
+)
+
+const diffSpec1JSON = `{
+  "openapi":"3.0.0","info":{"title":"S1","version":"1.0.0"},
+  "paths":{
+    "/a":{"get":{"operationId":"getA","responses":{"200":{"description":"ok"}}}},
+    "/b":{"get":{"operationId":"getB","responses":{"200":{"description":"ok"}}}}
+  },
+  "components":{"schemas":{
+    "Foo":{"type":"object"},
+    "Bar":{"type":"object"}
+  }}
+}`
+
+// diffSpec2JSON keeps endpoint GET /a but renames its operationId (getA -> listA),
+// drops GET /b, adds GET /c, and swaps schema Bar for Baz.
+const diffSpec2JSON = `{
+  "openapi":"3.0.0","info":{"title":"S2","version":"1.0.0"},
+  "paths":{
+    "/a":{"get":{"operationId":"listA","responses":{"200":{"description":"ok"}}}},
+    "/c":{"get":{"operationId":"getC","responses":{"200":{"description":"ok"}}}}
+  },
+  "components":{"schemas":{
+    "Foo":{"type":"object"},
+    "Baz":{"type":"object"}
+  }}
+}`
+
+func TestSpecsDiff(t *testing.T) {
+	spec1, err := Parse([]byte(diffSpec1JSON))
+	if err != nil {
+		t.Fatalf("Parse(spec1) error: %v", err)
+	}
+	spec2, err := Parse([]byte(diffSpec2JSON))
+	if err != nil {
+		t.Fatalf("Parse(spec2) error: %v", err)
+	}
+
+	d := SpecsDiff(spec1, spec2)
+
+	checks := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		// GET /a is shared; the differing operationId does not affect the endpoint set.
+		{"Endpoints OnlyInSpec1", d.OnlyInSpec1.Endpoints, []string{"/b GET"}},
+		{"Endpoints OnlyInSpec2", d.OnlyInSpec2.Endpoints, []string{"/c GET"}},
+		{"Endpoints Both", d.Both.Endpoints, []string{"/a GET"}},
+		// getA was renamed to listA, so no operationId is shared.
+		{"OperationIDs OnlyInSpec1", d.OnlyInSpec1.OperationIDs, []string{"getA", "getB"}},
+		{"OperationIDs OnlyInSpec2", d.OnlyInSpec2.OperationIDs, []string{"getC", "listA"}},
+		{"OperationIDs Both", d.Both.OperationIDs, []string{}},
+		{"SchemaNames OnlyInSpec1", d.OnlyInSpec1.SchemaNames, []string{"Bar"}},
+		{"SchemaNames OnlyInSpec2", d.OnlyInSpec2.SchemaNames, []string{"Baz"}},
+		{"SchemaNames Both", d.Both.SchemaNames, []string{"Foo"}},
+	}
+	for _, c := range checks {
+		if !reflect.DeepEqual(c.got, c.want) {
+			t.Errorf("%s: want %v, got %v", c.name, c.want, c.got)
+		}
+	}
+
+	if d.IsEmpty() {
+		t.Error("SpecMetadataDiff.IsEmpty() = true, want false for differing specs")
+	}
+}
+
+func TestSpecsDiffIdentical(t *testing.T) {
+	spec, err := Parse([]byte(diffSpec1JSON))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	d := SpecsDiff(spec, spec)
+	if !d.IsEmpty() {
+		t.Errorf("SpecsDiff(spec, spec).IsEmpty() = false, want true\n%s", d.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a general-purpose OpenAPI 3 spec diff to `openapi3`, modeled as the complement of the existing `Intersection` API, plus a `cmd/oas3diff` CLI.

Compares two specs across three independent dimensions — **endpoints** (generic `path method`, so param-name/operationId renames don't create false diffs), **operation IDs**, and **schema names** — reporting what is unique to each side and what is shared.

### API (`openapi3/difference.go`)

- `SpecMetadataDiff{OnlyInSpec1, OnlyInSpec2, Both}`
- `SpecsDiff(spec1, spec2 *Spec)` / `ReadSpecsDiff(file1, file2, validate)`
- `SpecMetadata.Diff(md2)` / `SpecMetadata.Difference(md2)`
- `SpecMetadataDiff.String()` / `IsEmpty()` / `Sort()`

### CLI (`cmd/oas3diff`)

`oas3diff <spec1> <spec2>` — reads JSON or YAML, prints per-dimension differences. Follows the `cmd/oas2meta` convention.

## Compatibility

Purely additive — no existing exported signature changed or removed; no breaking changes. Targets a **v1.21.0** minor release.

## Testing

- `openapi3/difference_test.go` covers all three dimensions, including that a renamed operationId on a shared endpoint is **not** reported as an endpoint difference.
- `go build ./...`, `go test ./openapi3/`, and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011FTq1mwEwZ183zXZfDvq8E